### PR TITLE
feat(landing): add footer component & update links with logos

### DIFF
--- a/package/landing/src/App.tsx
+++ b/package/landing/src/App.tsx
@@ -11,6 +11,7 @@ import {
   Alert,
 } from "@mui/material";
 import { darkTheme, lightTheme } from "@kogen/kogen-ui/src/lib/theme";
+import Footer from "./components/Footer";
 
 function App() {
   const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
@@ -106,36 +107,7 @@ function App() {
           </Box>
         </Card>
 
-        <Box sx={{ mt: 3, mb: 10, textAlign: "center" }}>
-          <Typography variant="caption">
-            <Link
-              color={"secondary"}
-              href="https://beta.howl.social/kogen"
-              target={"_blank"}
-              rel="noreferrer"
-            >
-              howl
-            </Link>{" "}
-            |{" "}
-            {/* <Link
-              color={"secondary"}
-              href="https://twitter.com/howlpack"
-              target={"_blank"}
-              rel="noreferrer"
-            >
-              twitter
-            </Link>{" "}
-            |{" "} */}
-            <Link
-              color={"secondary"}
-              href="https://github.com/kogen-markets/"
-              target={"_blank"}
-              rel="noreferrer"
-            >
-              github
-            </Link>
-          </Typography>
-        </Box>
+        <Footer />
       </Container>
     </ThemeProvider>
   );

--- a/package/landing/src/components/Footer.tsx
+++ b/package/landing/src/components/Footer.tsx
@@ -1,0 +1,77 @@
+import { Box, Grid, Link } from "@mui/material";
+import GitHubIcon from "@mui/icons-material/GitHub";
+import XIcon from "@mui/icons-material/X";
+import TelegramIcon from "@mui/icons-material/Telegram";
+import { Fragment } from "react/jsx-runtime";
+
+const links = [
+  {
+    logo: <GitHubIcon />,
+    text: "Check out our Github",
+    url: "https://github.com/kogen-markets/",
+  },
+  {
+    logo: <XIcon />,
+    text: "Follow us on X",
+    url: "https://x.com/KogenMarkets",
+  },
+  {
+    logo: <TelegramIcon />,
+    text: "Follow us on Telegram",
+    url: "https://t.me/+6OWwq2YaPKFjYTY9",
+  },
+];
+
+const Footer = () => {
+  return (
+    <Box
+      component="footer"
+      sx={{
+        backgroundColor: "transparent",
+        padding: "20px",
+      }}
+    >
+      <Grid container spacing={2} justifyContent="center">
+        {links.map((link, index) => (
+          <Fragment key={index}>
+            <Grid item sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <Link
+                href={link.url}
+                title={link.text}
+                target="_blank"
+                rel="noreferrer"
+                sx={{
+                  fontWeight: "bold",
+                  fontSize: 16,
+                  color: "white",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  "&:hover": { opacity: 0.8 },
+                }}
+              >
+                {link.logo}
+              </Link>
+            </Grid>
+
+            {/* Delimiter (Hide after last item) */}
+            {index < links.length - 1 && (
+              <Grid item>
+                <Box
+                  sx={{
+                    height: "24px",
+                    width: "1px",
+                    backgroundColor: "#ddd",
+                    mx: 2,
+                  }}
+                />
+              </Grid>
+            )}
+          </Fragment>
+        ))}
+      </Grid>
+    </Box>
+  );
+};
+
+export default Footer;


### PR DESCRIPTION
This PR introduces a footer component for the landing page to make the code more modular:
* easier to add a new link with its logo
* avoid conflicting modifications in 1 single `App.tsx` file

It also improves:
* the way we display the links with a better design
* the visibility using well-known logos & white color
* the delimiter by making it dynamic (no need to add ` | ` manually with specific spaces anymore)

In addition, this changes the following:
* remove howl link (dead link: https://beta.howl.social/kogen)
* remove commented link that is not used (https://twitter.com/howlpack)
* add X (ex-Twitter) link (https://x.com/KogenMarkets)
* add Telegram link (https://t.me/+6OWwq2YaPKFjYTY9)

See screenshots to compare between before & after this modification (in red):

Before | After
-------|------
<img width="1492" alt="image" src="https://github.com/user-attachments/assets/43203a31-7ab2-468c-bd57-250027a03f6d" />|<img width="1492" alt="image" src="https://github.com/user-attachments/assets/f5d760a1-7977-4e53-a34a-da2bd0a6ea5f" />