### PR TITLE
feat(landing): split disclaimer making it easier to update

### DIFF
--- a/package/landing/src/App.tsx
+++ b/package/landing/src/App.tsx
@@ -12,6 +12,7 @@ import {
 } from "@mui/material";
 import { darkTheme, lightTheme } from "@kogen/kogen-ui/src/lib/theme";
 import Footer from "./components/Footer";
+import Disclaimer from "./components/Disclaimer";
 
 function App() {
   const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
@@ -54,16 +55,7 @@ function App() {
             <img src="/kogen-logo-white.png" />
           )}
         </Box>
-        <Alert
-          severity="warning"
-          variant="outlined"
-          sx={{ backdropFilter: "blur(5px)" }}
-        >
-          Please note that Kogen is currently in active development. While we
-          strive to offer you the best user experience possible, it&apos;s
-          important to be aware that there may be occasional glitches or
-          limitations as we continue to refine and enhance the platform.
-        </Alert>
+        <Disclaimer />
         <Card
           sx={{ p: 3, mt: 4, backdropFilter: "blur(5px)" }}
           variant="outlined"

--- a/package/landing/src/components/Disclaimer.tsx
+++ b/package/landing/src/components/Disclaimer.tsx
@@ -1,0 +1,16 @@
+import { Alert } from "@mui/material";
+import disclaimerText from "./Disclaimer.txt?raw";
+
+const Disclaimer = () => {
+  return (
+    <Alert
+      severity="warning"
+      variant="outlined"
+      sx={{ backdropFilter: "blur(5px)" }}
+    >
+      {disclaimerText}
+    </Alert>
+  );
+};
+
+export default Disclaimer;

--- a/package/landing/src/components/Disclaimer.txt
+++ b/package/landing/src/components/Disclaimer.txt
@@ -1,0 +1,1 @@
+Please note that Kogen is currently in active development. While we strive to offer you the best user experience possible, it's important to be aware that there may be occasional glitches or limitations as we continue to refine and enhance the platform.


### PR DESCRIPTION
This PR splits the disclaimer alert in order to make its update easier by less tech-savvy people:
* isolate the disclaimer alert into a specific `Disclaimer.tsx` component
* isolate the disclaimer text into `Disclaimer.txt` file

To make an update of the disclaimer, we now just need to modify the file `Disclaimer.txt` making it very easy to update.