### PR TITLE
fix(landing): footer link colors

### DIFF
--- a/package/landing/src/components/Footer.tsx
+++ b/package/landing/src/components/Footer.tsx
@@ -40,10 +40,10 @@ const Footer = () => {
                 title={link.text}
                 target="_blank"
                 rel="noreferrer"
+                color="secondary"
                 sx={{
                   fontWeight: "bold",
                   fontSize: 16,
-                  color: "white",
                   display: "flex",
                   alignItems: "center",
                   gap: 1,


### PR DESCRIPTION
This PR fixes the colors for the footer links as on the light theme, white color became invisible.

Dark theme | Light theme
----|----
<img width="1493" alt="image" src="https://github.com/user-attachments/assets/0031e437-29e8-4329-89af-da9486b2f5ec" />|<img width="1493" alt="image" src="https://github.com/user-attachments/assets/d3688737-2327-4235-a53a-d0a074214e53" />