### PR TITLE
feat(landing): add about Kogen Markets link

### DIFF
--- a/package/landing/src/App.tsx
+++ b/package/landing/src/App.tsx
@@ -7,12 +7,11 @@ import {
   ThemeProvider,
   useMediaQuery,
   Typography,
-  Link,
-  Alert,
 } from "@mui/material";
 import { darkTheme, lightTheme } from "@kogen/kogen-ui/src/lib/theme";
 import Footer from "./components/Footer";
 import Disclaimer from "./components/Disclaimer";
+import TopNavBar from "./components/TopNavBar";
 
 function App() {
   const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
@@ -36,6 +35,7 @@ function App() {
         }}
       ></Box>
       <Container maxWidth="md">
+        <TopNavBar />
         <Box
           sx={{
             my: 5,
@@ -62,27 +62,29 @@ function App() {
           color="secondary"
         >
           <Typography variant="body1" sx={{ mb: 2 }}>
-            Welcome to Kogen Markets, the ultimate decentralized options trading platform
-            designed to revolutionize the way you trade call and put options. Built on
-            the principles of blockchain technology and powered by smart
-            contracts, Kogen Markets provides a secure, transparent, and decentralized
-            platform for trading vanilla options. With Kogen Markets, your orders go on-chain
-            on our decentralized limit order books, giving you the same access as any sophisticated trader.
+            Welcome to Kogen Markets, the ultimate decentralized options trading
+            platform designed to revolutionize the way you trade call and put
+            options. Built on the principles of blockchain technology and
+            powered by smart contracts, Kogen Markets provides a secure,
+            transparent, and decentralized platform for trading vanilla options.
+            With Kogen Markets, your orders go on-chain on our decentralized
+            limit order books, giving you the same access as any sophisticated
+            trader.
           </Typography>
           <Typography variant="body1" sx={{ my: 2 }} component="div">
             Our innovative platform empowers you to participate in trustless and
             efficient bidding and offering orders, ensuring fairness and equal
             opportunities for all participants. Whether you are a seasoned
-            options trader or new to the world of derivatives, Kogen Markets offers a
-            user-friendly interface and robust features to enhance your trading
-            experience.
+            options trader or new to the world of derivatives, Kogen Markets
+            offers a user-friendly interface and robust features to enhance your
+            trading experience.
           </Typography>
           <Typography variant="body1" sx={{ my: 2 }} component="div">
-            Experience the benefits of decentralized options trading with Kogen Markets,
-            where you can unleash your trading potential, take control of your
-            investments, and navigate the exciting realm of call and put options with
-            ease. Join us today and embark on a journey that reshapes the way
-            you approach options trading.
+            Experience the benefits of decentralized options trading with Kogen
+            Markets, where you can unleash your trading potential, take control
+            of your investments, and navigate the exciting realm of call and put
+            options with ease. Join us today and embark on a journey that
+            reshapes the way you approach options trading.
           </Typography>
 
           <Box sx={{ textAlign: "center", mt: 6, mb: 3 }}>

--- a/package/landing/src/components/TopNavBar.tsx
+++ b/package/landing/src/components/TopNavBar.tsx
@@ -1,0 +1,43 @@
+import {
+  useTheme,
+  Button,
+  Container,
+  Toolbar,
+  Box,
+  AppBar,
+} from "@mui/material";
+
+const links = [
+  {
+    name: "About Kogen Markets",
+    url: "https://medium.com/@kogen.markets",
+    target: "_blank",
+  },
+];
+
+function TopNavBar() {
+  const theme = useTheme();
+  const buttonTextColor = theme.palette.mode == "light" ? "#000000" : "#FFFFFF";
+  return (
+    <AppBar position="static" color="transparent" elevation={0}>
+      <Container maxWidth="xl">
+        <Toolbar disableGutters>
+          <Box sx={{ flexGrow: 1, display: "flex" }} />
+          <Box sx={{ display: "flex" }}>
+            {links.map((link) => (
+              <Button
+                key={link.name}
+                href={link.url}
+                target={link.target}
+                sx={{ my: 2, color: buttonTextColor, display: "block" }}
+              >
+                {link.name}
+              </Button>
+            ))}
+          </Box>
+        </Toolbar>
+      </Container>
+    </AppBar>
+  );
+}
+export default TopNavBar;


### PR DESCRIPTION
This PR:
- introduces a top navigation bar component handling both dark/light mode themes + easy way to add a new link
- adds a button link to [Kogen Markets' Medium page](https://medium.com/@kogen.markets) under the link "About Kogen Markets"

dark mode | light mode
-----|-----
<img width="1492" alt="image" src="https://github.com/user-attachments/assets/afed34d2-e0f3-436e-81fe-009078a07fac" />|<img width="1492" alt="image" src="https://github.com/user-attachments/assets/208bfb52-6da3-4dde-9c3a-cfc3a27c2d54" />
