### PR TITLE
docs: explain the node-polyfills fix for issue #96

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Kogen is a project that utilizes npm workspaces to manage multiple packages with
   - [Installation](#installation)
 - [Development](#development)
 - [Testing Production Build](#testing-production-build)
+- [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -87,3 +88,18 @@ To build and serve the production version of the UI package:
    ```
    npx serve package/ui/dist
    ```
+
+## Troubleshooting
+
+### `TypeError: Cannot read properties of undefined (reading 'isBuffer')` when submitting an order
+
+This is caused by missing Node.js polyfills (`Buffer`, `crypto`, `stream`) in
+the browser bundle, which the Injective SDK depends on. The fix — configuring
+`vite-plugin-node-polyfills` instead of patching `keccak256` with
+`patch-package` — is documented in detail in the
+[UI package README](package/ui/README.md#node-polyfills-fix-for-issue-96).
+See issue [#96](https://github.com/kogen-markets/app/issues/96) and
+PR [#98](https://github.com/kogen-markets/app/pull/98).
+
+If dependency-related errors persist after upgrading packages, clear Vite's
+dependency cache with `npm run vite` (removes `package/ui/node_modules/.vite/deps`).

--- a/package/ui/README.md
+++ b/package/ui/README.md
@@ -71,9 +71,44 @@ Currently, there are no tests implemented. The test script exits successfully:
 npm test
 ```
 
-## Node Polyfills
+## Node Polyfills (fix for issue #96)
 
-This project uses `vite-plugin-node-polyfills` to provide Node.js polyfills for the browser environment. This is particularly useful when working with libraries that depend on Node.js built-in modules.
+The Injective SDK (`@injectivelabs/*`) and its transitive dependencies (notably
+`keccak256`) rely on Node.js built-ins such as `Buffer`, `crypto`, and
+`stream`, which do not exist in the browser and are not polyfilled by Vite by
+default. Without polyfills, submitting a bid or ask order crashes at runtime
+with:
+
+```
+TypeError: Cannot read properties of undefined (reading 'isBuffer')
+    at toBuffer (...)
+    at keccak256 (...)
+    at createTransactionWithSigners (...)
+```
+
+(Reported as [#96](https://github.com/kogen-markets/app/issues/96).)
+
+The original workaround was a `patch-package` patch that hand-edited
+`node_modules/keccak256` to import `Buffer` and set it on `globalThis`. That
+approach was fragile — it broke whenever the dependency tree shifted — and was
+removed in [#98](https://github.com/kogen-markets/app/pull/98) in favor of
+configuring the bundler properly in [`vite.config.ts`](./vite.config.ts):
+
+- `vite-plugin-node-polyfills` is configured with
+  `include: ['crypto', 'stream', 'assert', 'util']`. The plugin also injects
+  the `Buffer` and `process` globals, which is what the crash was actually
+  about.
+- `resolve.alias` maps `stream` to `stream-browserify` (with `assert` and
+  `util` aliased to their npm polyfill packages) so bare imports of Node
+  built-ins resolve to browser-compatible implementations.
+- `optimizeDeps.include` lists `@metamask/obs-store` so Vite pre-bundles this
+  CommonJS dependency during dev.
+
+If you see `Buffer`/`isBuffer`/`crypto`-related errors after upgrading wallet
+or Injective SDK dependencies, check that the polyfill configuration in
+`vite.config.ts` still covers the modules those packages expect. Clearing
+Vite's dependency cache can also help: `npm run vite` from the repository root
+(removes `package/ui/node_modules/.vite/deps`).
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

Issue #96 (`TypeError: Cannot read properties of undefined (reading 'isBuffer')` when submitting an order) was fixed in #98 by replacing the `patch-package` edit of `keccak256` with a proper `vite-plugin-node-polyfills` configuration — but the reasoning behind that fix isn't documented anywhere, so the polyfill config in `vite.config.ts` is easy to break unknowingly during future dependency upgrades.

This PR is documentation only:

- Expands the **Node Polyfills** section in `package/ui/README.md` with the original error, its root cause (Node.js built-ins like `Buffer`/`crypto`/`stream` missing in the browser bundle, needed by the Injective SDK and `keccak256`), why the old `patch-package` approach was fragile, and what each part of the `vite.config.ts` configuration does.
- Adds a **Troubleshooting** section to the root README that names the exact error message and links to the detailed writeup, plus the `npm run vite` cache-clearing tip.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)